### PR TITLE
Begin end of function fixes

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -342,7 +342,7 @@ The following keys are bound:
     (modify-syntax-entry ?^ ".")
     ;; This might be better as punctuation, as for C, but this way you
     ;; can treat table index as symbol.
-    (modify-syntax-entry ?. "_")	; e.g. `io.string'
+    (modify-syntax-entry ?. "_")        ; e.g. `io.string'
     (modify-syntax-entry ?> ".")
     (modify-syntax-entry ?< ".")
     (modify-syntax-entry ?= ".")
@@ -565,7 +565,7 @@ matching keyword that ends the block, and vice versa."
   (let ((position (lua-goto-matching-block-token)))
     (if (and (not position)
              (not noreport))
-        (error "Not on a block control keyword or brace.")
+        (error "Not on a block control keyword or brace")
       position)))
 
 (defun lua-forward-line-skip-blanks (&optional back)


### PR DESCRIPTION
Hi. In case you're interested, here's a small fix so we can have a working narrow-to-defun for free.
It also removes the explicit bindings for C-M-a, C-M-e and friends, lets the global beginning-of-defun and end-of-defun commands (bindings) take over.

Thank you for lua-mode! Keep up the good work. :-) 

Cheers! 
Leo.
