### PR TITLE
Added autoload for (add-to-list 'interpreter-mode-alist '("lua" . lua-mode))

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -375,6 +375,9 @@ The following keys are bound:
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.lua$" . lua-mode))
 
+;;;###autoload
+(add-to-list 'interpreter-mode-alist '("lua" . lua-mode))
+
 (defun lua-electric-match (arg)
   "Insert character and adjust indentation."
   (interactive "P")


### PR DESCRIPTION
Since `lua-mode` and `(add-to-list 'auto-mode-alist '("\\.lua$" . lua-mode))` already have autoloads maybe `(add-to-list 'interpreter-mode-alist '("lua" . lua-mode))` should also have one for generating autoloads.
