### PR TITLE
Fix highlighting of single-line comments

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -493,21 +493,21 @@ index of respective Lua reference manuals.")
 
 (defvar lua-mode-syntax-table
   (let ((st (copy-syntax-table)))
-    (modify-syntax-entry ?+ ".")
-    (modify-syntax-entry ?- ". 12")
-    (modify-syntax-entry ?* ".")
-    (modify-syntax-entry ?/ ".")
-    (modify-syntax-entry ?^ ".")
+    (modify-syntax-entry ?+ "." st)
+    (modify-syntax-entry ?- ". 12" st)
+    (modify-syntax-entry ?* "." st)
+    (modify-syntax-entry ?/ "." st)
+    (modify-syntax-entry ?^ "." st)
     ;; This might be better as punctuation, as for C, but this way you
     ;; can treat table index as symbol.
-    (modify-syntax-entry ?. "_")        ; e.g. `io.string'
-    (modify-syntax-entry ?> ".")
-    (modify-syntax-entry ?< ".")
-    (modify-syntax-entry ?= ".")
-    (modify-syntax-entry ?~ ".")
-    (modify-syntax-entry ?\n ">")
-    (modify-syntax-entry ?\' "\"")
-    (modify-syntax-entry ?\" "\"")
+    (modify-syntax-entry ?. "_" st)     ; e.g. `io.string'
+    (modify-syntax-entry ?> "." st)
+    (modify-syntax-entry ?< "." st)
+    (modify-syntax-entry ?= "." st)
+    (modify-syntax-entry ?~ "." st)
+    (modify-syntax-entry ?\n ">" st)
+    (modify-syntax-entry ?\' "\"" st)
+    (modify-syntax-entry ?\" "\"" st)
     st)
   "Syntax table used while in `lua-mode'.")
 


### PR DESCRIPTION
I seem to have been experiencing the same issues as #42, this fixes it in emacs trunk, I haven't checked it on any other version of emacs, but as long as the parameters for `modify-syntax-entry` haven't changed I can't imagine it breaking anything.
