### PR TITLE
lua-beginning-of-proc: improve defun header regex

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -1537,6 +1537,11 @@ If not, return nil."
        ;; 4. if there's no previous line, indentation is 0
        0))))
 
+(defvar lua--beginning-of-defun-re
+  (lua-rx-to-string '(: bol (? (symbol "local") ws+) lua-funcheader))
+  "Lua top level (matches only at the beginning of line) function header regex.")
+
+
 (defun lua-beginning-of-proc (&optional arg)
   "Move backward to the beginning of a lua proc (or similar).
 
@@ -1548,11 +1553,11 @@ Returns t unless search stops due to beginning or end of buffer."
   (or arg (setq arg 1))
 
   (while (and (> arg 0)
-              (re-search-backward "^function[ \t]" nil t))
+              (re-search-backward lua--beginning-of-defun-re nil t))
     (setq arg (1- arg)))
 
   (while (and (< arg 0)
-              (re-search-forward "^function[ \t]" nil t))
+              (re-search-forward lua--beginning-of-defun-re nil t))
     (beginning-of-line)
     (setq arg (1+ arg)))
 

--- a/test/generic-test.el
+++ b/test/generic-test.el
@@ -19,3 +19,53 @@
       "--[[end here]] end"))
    (lua-forward-sexp)
    (should (looking-back (rx "--[[end here]] end")))))
+
+(ert-deftest lua-beginning-of-defun-different-headers ()
+  (with-lua-buffer
+   (lua-insert-goto-<>
+    '("function foobar()"
+      "<>"
+      "end"))
+   (beginning-of-defun)
+   (should (looking-at "function foobar()")))
+
+  (with-lua-buffer
+   (lua-insert-goto-<>
+    '("local function foobar()"
+      "<>"
+      "end"))
+   (beginning-of-defun)
+   (should (looking-at "local function foobar()")))
+
+  (with-lua-buffer
+   (lua-insert-goto-<>
+    '("local foobar = function()"
+      "<>"
+      "end"))
+   (beginning-of-defun)
+   (should (looking-at "local foobar = function()")))
+
+  (with-lua-buffer
+   (lua-insert-goto-<>
+    '("foobar = function()"
+      "<>"
+      "end"))
+   (beginning-of-defun)
+   (should (looking-at "foobar = function()"))))
+
+(ert-deftest lua-beginning-of-defun-accepts-dots-and-colons ()
+   (with-lua-buffer
+    (lua-insert-goto-<>
+     '("foo.bar = function (x,y,z)"
+       "<>"
+       "end"))
+    (beginning-of-defun)
+    (should (looking-at "foo\\.bar = function (x,y,z)")))
+
+   (with-lua-buffer
+    (lua-insert-goto-<>
+     '("function foo.bar:baz (x,y,z)"
+       "<>"
+       "end"))
+    (beginning-of-defun)
+    (should (looking-at "function foo.bar:baz (x,y,z)"))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -77,6 +77,7 @@ This is a mere typing/reading aid for lua-mode's font-lock tests."
   (mapconcat (lambda (x) (concat x "\n")) strs ""))
 
 (defmacro with-lua-buffer (&rest body)
+  (declare (debug (&rest form)))
   `(with-temp-buffer
      (lua-mode)
      (set (make-local-variable 'lua-process) nil)


### PR DESCRIPTION
Now `lua-beginning-of-proc` finds all common Lua function headers, including:
- `local function XXX(...)`
- `XXX = function(...)`
- `XXX = local function(...)`

This should fix #84.