### PR TITLE
lua-process-init-code: use load when loadstring is not available

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -1596,7 +1596,8 @@ This function just searches for a `end' at the beginning of a line."
 (defvar lua-process-init-code
   (mapconcat
    'identity
-   '("function luamode_loadstring(str, displayname, lineoffset)"
+   '("local loadstring = loadstring or load"
+     "function luamode_loadstring(str, displayname, lineoffset)"
      "  if lineoffset > 1 then"
      "    str = string.rep('\\n', lineoffset - 1) .. str"
      "  end"


### PR DESCRIPTION
loadstring is deprecated in Lua 5.2 and removed in Lua 5.3.