### PR TITLE
Add # length operator to syntax as punctuation

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -683,6 +683,7 @@ Groups 6-9 can be used in any of argument regexps."
     (modify-syntax-entry ?\" "\"")
 
     ;; single-character binary operators: punctuation
+    (modify-syntax-entry ?# ".")
     (modify-syntax-entry ?+ ".")
     (modify-syntax-entry ?* ".")
     (modify-syntax-entry ?/ ".")


### PR DESCRIPTION
Using the `#` length operator was being highlighted as a comment, and bleeding through all the code below that point.

```
a = {1,2,3}
print(#a)
print("this should not be highlighted as a comment")
```

With point at "this", `describe-face` was reporting "font-lock-comment-face". After this patch, it correctly reports "font-lock-string-face".
