### PR TITLE
Allow to set lua-indent-level as file local variable

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -228,7 +228,8 @@ for Emacsen that doesn't contain one (pre-23.3)."
 (defcustom lua-indent-level 3
   "Amount by which Lua subexpressions are indented."
   :type 'integer
-  :group 'lua)
+  :group 'lua
+  :safe #'integerp)
 
 (defcustom lua-comment-start "-- "
   "Default value of `comment-start'."


### PR DESCRIPTION
Sometimes it can be useful to set the indentation level on per file/directory level for different projects