### PR TITLE
Escape tabs in lua-make-lua-string

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -1708,10 +1708,14 @@ This function just searches for a `end' at the beginning of a line."
     (with-temp-buffer
       (insert str)
       (goto-char (point-min))
-      (while (re-search-forward "[\"'\\\n]" nil t)
-        (if (string= (match-string 0) "\n")
-            (replace-match "\\\\n")
-          (replace-match "\\\\\\&" t)))
+      (while (re-search-forward "[\"'\\\t\\\n]" nil t)
+        (cond
+	 ((string= (match-string 0) "\n")
+	  (replace-match "\\\\n"))
+	 ((string= (match-string 0) "\t")
+	  (replace-match "\\\\t"))
+	 (t
+          (replace-match "\\\\\\&" t))))
       (concat "'" (buffer-string) "'"))))
 
 ;;;###autoload

--- a/test/test-inferior-process.el
+++ b/test/test-inferior-process.el
@@ -142,3 +142,10 @@ function () end
           (kill-buffer buf))
         (delete-file fname)
         (kill-buffer "*lua*")))))
+
+(describe "String escaping"
+  (it "Escapes literal tabs"
+    (expect (string=
+	     (lua-make-lua-string "\
+	-- comment indented with a tab")
+	     "'\\t-- comment indented with a tab'"))))


### PR DESCRIPTION
Doing so prevents comint from intercepting the tabs and passing them to
the underlying shell process, which inserts shell tab completion text
into the code string, mangling it so that it can't run.

-----

As noted in the commit description. This probably isn't the right solution; the
better one would be to tell comint not to touch the input string, but I'm not
sure how to do that. Nonetheless, it's still a solution, and it fixes the bug at
hand.