### PR TITLE
Support querying subprocess for completion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ hash-bang line (`#!/usr/bin/lua`). Putting this snippet to `.emacs` should be en
 - documentation lookup (using online/offline reference manual, e.g. [string.find](http://www.lua.org/manual/5.1/manual.html#pdf-string.find))
 - [imenu](http://www.gnu.org/software/emacs/manual/html_node/emacs/Imenu.html) integration
 - [HideShow](http://www.gnu.org/software/emacs/manual/html_node/emacs/Hideshow.html) integration
+- using `completion-at-point` queries active Lua subprocess for completion targets
 
 ## CUSTOMIZATION
 
@@ -56,6 +57,7 @@ The following variables are available for customization (see more via `M-x custo
 - Var `lua-mode-hook`: list of functions to execute when lua-mode is initialized
 - Var `lua-documentation-url` (default `"http://www.lua.org/manual/5.1/manual.html#pdf-"`): base URL for documentation lookup
 - Var `lua-documentation-function` (default `browse-url`): function used to show documentation (`eww` is a viable alternative for Emacs 25)
+- Var `lua-local-require-completions` (default `nil`): set to `t` to have completion attempt to load local libraries for current file for completion targets; can cause unexpected side-effects
 
 ## LUA SUBPROCESS CREATION
 

--- a/lua-mode.el
+++ b/lua-mode.el
@@ -1929,6 +1929,7 @@ This is distinct from `backward-sexp' which treats . and : as a separator."
 Queries current lua subprocess for possible completions."
   (let* ((start-of-expr (lua-start-of-expr))
          (expr (buffer-substring-no-properties start-of-expr (point)))
+         (expr (car (last (split-string expr "\n")))) ; avoid multi-line input
          (libs (lua-local-libs))
          (file (make-temp-file "lua-completions-")))
     (lua-send-string (lua-completion-string-for expr libs file))

--- a/lua-mode.el
+++ b/lua-mode.el
@@ -1884,7 +1884,7 @@ by `lua-local-libs', or nil."
                "  f:write(l .. string.char(10))"
                "end"
                "f:close()"
-               "end") "\n"))
+               "end") " "))
 
 (defvar lua-local-require-completions nil
   "During completion, scan file for local require calls for context.

--- a/lua-mode.el
+++ b/lua-mode.el
@@ -1932,15 +1932,14 @@ This is distinct from `backward-sexp' which treats . and : as a separator."
 
 Queries current lua subprocess for possible completions."
   (let* ((start-of-expr (lua-start-of-expr))
-         (start-of-token (save-excursion (when (symbol-at-point)
-                                           (backward-sexp)) (point)))
          (expr (buffer-substring-no-properties start-of-expr (point)))
          (libs (lua-local-libs))
          (file (make-temp-file "lua-completions-")))
     (lua-send-string (lua-completion-string-for expr libs file))
     (sit-for 0.1)
     (unwind-protect
-        (list start-of-token (point)
+        (list (save-excursion (when (symbol-at-point)
+                                (backward-sexp)) (point)) (point)
               (when (file-exists-p file)
                 (with-temp-buffer
                   (insert-file-contents file)

--- a/lua-mode.el
+++ b/lua-mode.el
@@ -1829,9 +1829,8 @@ If `lua-process' is nil or dead, start a new process first."
         (error "Not on a function definition")))))
 
 (defun lua-completion-trim-input (i)
-  (format "'%s'," (with-temp-buffer (insert i) (goto-char 0)
-                                   (replace-regexp "[[:space:]]" "")
-                                   (buffer-string))))
+  (format "'%s'," (replace-regexp-in-string "[[:space:]]" "" i)))
+
 
 (defun lua-completion-string-for (expr libs out-file)
   "Construct a string of Lua code to write completions to `out-file'.
@@ -1935,12 +1934,17 @@ Queries current lua subprocess for possible completions."
     (lua-send-string (lua-completion-string-for expr libs file))
     (sit-for 0.1)
     (unwind-protect
-        (list (save-excursion (when (symbol-at-point)
-                                (backward-sexp)) (point)) (point)
+        (list (save-excursion
+                (when (symbol-at-point) (backward-sexp))
+                (point))
+              (point)
               (when (file-exists-p file)
                 (with-temp-buffer
                   (insert-file-contents file)
-                  (butlast (split-string (buffer-string) "\n")))))
+                  (butlast (split-string
+                            (buffer-substring-no-properties
+                             (point-min) (point-max))
+                            "\n")))))
       (delete-file file))))
 
 (defun lua-maybe-skip-shebang-line (start)

--- a/lua-mode.el
+++ b/lua-mode.el
@@ -1854,7 +1854,7 @@ by `lua-local-libs', or nil."
                                    (car l) (cadr l))) libs)
 
                ;; recursively delve into context based on input_parts
-               "local function cpl_for(input_parts, ctx, prefixes)"
+               "local function cpl_for(input_parts, ctx)"
                "  if type(ctx) ~= \"table\" then return {} end"
                "  if #input_parts == 0 and ctx ~= top_ctx then"
                "    return ctx"
@@ -1862,16 +1862,13 @@ by `lua-local-libs', or nil."
                "    local matches = {}"
                "    for k in pairs(ctx) do"
                "      if k:find('^' .. input_parts[1]) then"
-               "        local parts = clone(prefixes)"
-               "        table.insert(parts, k)"
-               "        table.insert(matches, table.concat(parts, '.'))"
+               "        table.insert(matches, k)"
                "      end"
                "    end"
                "    return matches"
                "  else" ; more segments of input remain; descend into ctx table
                "    local token1 = table.remove(input_parts, 1)"
-               "    table.insert(prefixes, first_part)"
-               "    return cpl_for(input_parts, ctx[token1], prefixes)"
+               "    return cpl_for(input_parts, ctx[token1])"
                "  end"
                "end"
 
@@ -1880,7 +1877,7 @@ by `lua-local-libs', or nil."
                ,@(mapcar 'lua-completion-trim-input (split-string expr "\\.")) "}"
                ;; spit it out to a file; lua-mode can't send data back to emacs
                ,(format "local f = io.open('%s', 'w')" out-file)
-               "for _,l in ipairs(cpl_for(input, top_ctx, {})) do"
+               "for _,l in ipairs(cpl_for(input, top_ctx)) do"
                "  f:write(l .. string.char(10))"
                "end"
                "f:close()"

--- a/lua-mode.el
+++ b/lua-mode.el
@@ -1884,7 +1884,7 @@ by `lua-local-libs', or nil."
                "  f:write(l .. string.char(10))"
                "end"
                "f:close()"
-               "end") " "))
+               "end") "\n"))
 
 (defvar lua-local-require-completions nil
   "During completion, scan file for local require calls for context.
@@ -1918,9 +1918,9 @@ This is distinct from `backward-sexp' which treats . and : as a separator."
   (save-excursion
     (backward-sexp)
     (let ((bos (point)))
-      (backward-char)
+      (when (> (point) 1) (backward-char))
       (when (string-match "[[:space:]]" (thing-at-point 'char))
-        (search-backward-regexp "[^\s-]" nil t)
+        (search-backward-regexp "[^\n\s-]" nil t)
         (when (string= (thing-at-point 'char) "\n")
           (backward-char)))
       (if (member (thing-at-point 'char) '(":" "."))

--- a/test/file.lua
+++ b/test/file.lua
@@ -1,0 +1,1 @@
+return {abc = 123, def = 456}

--- a/test/test-completion.el
+++ b/test/test-completion.el
@@ -1,0 +1,56 @@
+;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) -*-
+(load (concat (file-name-directory (or load-file-name (buffer-file-name)
+                                       default-directory))
+              "utils.el") nil 'nomessage 'nosuffix)
+(require 'cl-lib)
+
+(describe "Test lua-complete-function"
+  (it "completes top-level globals"
+    (with-lua-buffer
+     (insert "tabl")
+     (run-lua)
+     (completion-at-point)
+     (expect (buffer-string) :to-equal "table")))
+  (it "completes nested globals"
+    (with-lua-buffer
+     (insert "table.ins")
+     (run-lua)
+     (completion-at-point)
+     (expect (buffer-string) :to-equal "table.insert")))
+  (it "completes nested globals with spaces"
+    (with-lua-buffer
+     (insert "table. ins")
+     (run-lua)
+     (completion-at-point)
+     (expect (buffer-string) :to-equal "table. insert")))
+    (it "completes nested globals inside function call"
+    (with-lua-buffer
+     (insert "print(table.con)")
+     (backward-char)
+     (run-lua)
+     (completion-at-point)
+     (expect (buffer-string) :to-equal "print(table.concat)")))
+  (it "completes nested globals with newline"
+    (with-lua-buffer
+     (insert "table.\n  ins")
+     (run-lua)
+     (completion-at-point)
+     (expect (buffer-string) :to-equal "table.\n  insert"))))
+
+(describe "Test lua-complete-function with lua-local-require-regexp"
+  (it "completes locally-required libraries"
+    (with-lua-buffer
+     (insert "local xyz = require('test.file')\n")
+     (insert "xy")
+     (let ((lua-local-require-completions t))
+       (run-lua)
+       (completion-at-point))
+     (expect (thing-at-point 'line) :to-equal "xyz")))
+  (it "completes values nested in locally-required libraries"
+    (with-lua-buffer
+     (insert "local xyz = require('test.file')\n")
+     (insert "xyz.ab")
+     (let ((lua-local-require-completions t))
+       (run-lua)
+       (completion-at-point))
+     (expect (thing-at-point 'line) :to-equal "xyz.abc"))))


### PR DESCRIPTION
Fixes #87.

I ended up disabling the feature that pulls completion targets from locals by default since it can cause unexpected side-effects, but it's documented in the readme how to turn it on.
