### PR TITLE
Enhance indentation of blocks 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ modules to your Emacs and keeping them up-to-date. Once you have **el-get** set 
 and updating is no more than
 
     <M-x> el-get-update "lua-mode"`
-    
+
 Please, consult with [el-get documentation](https://github.com/dimitri/el-get/blob/master/README.md) for further information.
 
 ### MANUAL INSTALLATION
@@ -53,6 +53,7 @@ The following variables are available for customization (see more via `M-x custo
 
 - Var `lua-indent-level` (default `3`): indentation offset in spaces
 - Var `lua-indent-string-contents` (default `nil`): set to `t` if you like to have contents of multiline strings to be indented like comments
+- Var `lua-indent-nested-block-content-align` (default `t`) set to `nil` to stop aligning the content of nested blocks with the open parenthesis
 - Var `lua-mode-hook`: list of functions to execute when lua-mode is initialized
 - Var `lua-documentation-url` (default `"http://www.lua.org/manual/5.1/manual.html#pdf-"`): base URL for documentation lookup
 - Var `lua-documentation-function` (default `browse-url`): function used to show documentation (`eww` is a viable alternative for Emacs 25)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following variables are available for customization (see more via `M-x custo
 - Var `lua-indent-level` (default `3`): indentation offset in spaces
 - Var `lua-indent-string-contents` (default `nil`): set to `t` if you like to have contents of multiline strings to be indented like comments
 - Var `lua-indent-nested-block-content-align` (default `t`) set to `nil` to stop aligning the content of nested blocks with the open parenthesis
+- Var `lua-indent-close-paren-align` (defaut `t`) set to `t` to align close parenthesis with the open parenthesis rather than with the beginning of the line
 - Var `lua-mode-hook`: list of functions to execute when lua-mode is initialized
 - Var `lua-documentation-url` (default `"http://www.lua.org/manual/5.1/manual.html#pdf-"`): base URL for documentation lookup
 - Var `lua-documentation-function` (default `browse-url`): function used to show documentation (`eww` is a viable alternative for Emacs 25)

--- a/lua-mode.el
+++ b/lua-mode.el
@@ -55,6 +55,9 @@
 ;; - Var `lua-indent-nested-block-content-align':
 ;;   set to `nil' to stop aligning the content of nested blocks with the
 ;;   open parenthesis
+;; - Var `lua-indent-close-paren-align':
+;;   set to `t' to align close parenthesis with the open parenthesis,
+;;   rather than with the beginning of the line
 ;; - Var `lua-mode-hook':
 ;;   list of functions to execute when lua-mode is initialized
 ;; - Var `lua-documentation-url':
@@ -366,6 +369,13 @@ Otherwise leading amount of whitespace on each line is preserved."
   "If non-nil, the contents of nested blocks are indented to
 align with the column of the opening parenthesis, rather than
 just forward by `lua-indent-level'."
+  :group 'lua
+  :type 'boolean)
+
+(defcustom lua-indent-close-paren-align t
+  "If non-nil, close parenthesis are aligned with their open
+parenthesis.  If nil, close parenthesis are aligned to the
+beginning of the line."
   :group 'lua
   :type 'boolean)
 
@@ -1548,7 +1558,8 @@ If not, return nil."
         (when (lua-goto-matching-block-token block-token-pos 'backward)
           ;; Exception cases: when the start of the line is an assignment,
           ;; go to the start of the assignment instead of the matching item
-          (if (lua-point-is-after-left-shifter-p)
+          (if (or (not lua-indent-close-paren-align)
+                  (lua-point-is-after-left-shifter-p))
               (current-indentation)
             (current-column)))))))
 

--- a/lua-mode.el
+++ b/lua-mode.el
@@ -52,6 +52,9 @@
 ;; - Var `lua-indent-string-contents':
 ;;   set to `t` if you like to have contents of multiline strings to be
 ;;   indented like comments
+;; - Var `lua-indent-nested-block-content-align':
+;;   set to `nil' to stop aligning the content of nested blocks with the
+;;   open parenthesis
 ;; - Var `lua-mode-hook':
 ;;   list of functions to execute when lua-mode is initialized
 ;; - Var `lua-documentation-url':
@@ -356,6 +359,13 @@ Usually, stdin:XX line number points to nowhere."
 (defcustom lua-indent-string-contents nil
   "If non-nil, contents of multiline string will be indented.
 Otherwise leading amount of whitespace on each line is preserved."
+  :group 'lua
+  :type 'boolean)
+
+(defcustom lua-indent-nested-block-content-align t
+  "If non-nil, the contents of nested blocks are indented to
+align with the column of the opening parenthesis, rather than
+just forward by `lua-indent-level'."
   :group 'lua
   :type 'boolean)
 
@@ -1260,7 +1270,8 @@ use standalone."
     (cons 'relative lua-indent-level))
 
    ;; block openers
-   ((member found-token (list "{" "(" "["))
+   ((and lua-indent-nested-block-content-align
+	 (member found-token (list "{" "(" "[")))
     (save-excursion
       (let ((found-bol (line-beginning-position)))
         (forward-comment (point-max))

--- a/test/test-indentation.el
+++ b/test/test-indentation.el
@@ -501,10 +501,91 @@ foobar(
       b
    },
    c, d
-)"))))
+)")))
 
+  (it "indent blocks with lua-indent-nested-block-content-align"
+	(let ((lua-indent-nested-block-content-align nil))
+	  (expect (lua--reindent-like "\
+call_some_fn( something, {
+      val = 5,
+      another = 6,
+} )"))
+	  (expect (lua--reindent-like "\
+local def = {
+   some_very_long_name = { fn =
+         function()
+            return true
+         end
+   }
+}"))
+	  ))
 
+  (it "indent blocks with lua-indent-close-paren-align"
+	(let ((lua-indent-close-paren-align nil))
+	  (expect (lua--reindent-like "\
+local foo = setmetatable( {
+      a = 4,
+      b = 5,
+}, {
+      __index = some_func,
+} )"))
+	  ))
 
+  (it "indents nested tables with alternative block indenting"
+	(let ((lua-indent-nested-block-content-align nil)
+		  (lua-indent-close-paren-align nil))
+	  (expect (lua--reindent-like "\
+foobar({
+      a, b, c
+})"))
+
+	  (expect (lua--reindent-like "\
+foobar(a, {
+      b,
+      c
+})"))
+
+	  (expect (lua--reindent-like "\
+foobar(
+   a,
+   {
+      b,
+      c
+})"))
+
+	  (expect (lua--reindent-like "\
+foobar(
+   a,
+   {
+      b,
+      c
+   }
+)"))
+
+	  (expect (lua--reindent-like "\
+foobar(a,
+   {
+      b,
+      c
+})"))
+
+	  (expect (lua--reindent-like "\
+foobar(a,
+   {
+      b,
+      c
+   }
+)"))
+
+	  (expect (lua--reindent-like "\
+foobar(
+   {
+      a,
+      b
+   },
+   c, d
+)"))
+	  )))
 
 (ert-deftest lua-indentation-defun ()
   ;; 	 [local] function funcname funcbody


### PR DESCRIPTION
Added `lua-indent-nested-block-content-align` var, which disables the aligning of content of nested blocks to the opening brace and indents normally.  It defaults to `t`, which is the previous behaviour.

E.g. 1:

With `lua-indent-nested-block-content-align` set `t` (default), then:
```lua
call_some_fn( something, {
                val = 5,
                another = 6,
} )
```

Wth `lua-indent-nested-block-content-align` set `nil`, then:
```lua
call_some_fn( something, {
    val = 5,
    another = 6,
} )
```

E.g. 2:

With `lua-indent-nested-block-content-align` set `t` (default), then:
```lua
local def = {
  some_very_long_name = { fn =
                            function()
                              return true
                            end
  }
}
```

Wth `lua-indent-nested-block-content-align` set `nil`, then:
```lua
local def = {
  some_very_long_name = { fn =
      function()
        return true
      end
  }
}
```