### PR TITLE
Set comint-prompt-regexp locally in process buffer

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -709,9 +709,6 @@ Groups 6-9 can be used in any of argument regexps."
   :abbrev-table lua-mode-abbrev-table
   :syntax-table lua-mode-syntax-table
   :group 'lua
-  (setq comint-prompt-regexp lua-prompt-regexp)
-
-
   (setq-local font-lock-defaults '(lua-font-lock-keywords ;; keywords
                                         nil                    ;; keywords-only
                                         nil                    ;; case-fold
@@ -1738,7 +1735,8 @@ When called interactively, switch to the process buffer."
     (setq compilation-error-regexp-alist
           (cons (list lua-traceback-line-re 1 2)
                 compilation-error-regexp-alist))
-    (compilation-shell-minor-mode 1))
+    (compilation-shell-minor-mode 1)
+    (setq-local comint-prompt-regexp lua-prompt-regexp))
 
   ;; when called interactively, switch to process buffer
   (if (called-interactively-p 'any)

--- a/test/test-inferior-process.el
+++ b/test/test-inferior-process.el
@@ -3,7 +3,7 @@
                                        default-directory))
               "utils.el") nil 'nomessage 'nosuffix)
 (require 'cl-lib)
-
+(require 'comint)
 
 
 (describe "Hiding process buffer does not switch current window"
@@ -29,6 +29,16 @@
        (expect lua-process-buffer :to-be nil)
        (lua-hide-process-buffer)
        (expect (get-buffer-window cur-buf))))))
+
+(describe "Compilation minor mode"
+  (it "sets comint-prompt-regexp in process buffer"
+    (with-lua-buffer
+     (lua-start-process)
+     (with-current-buffer lua-process-buffer
+       (expect "" :not :to-match comint-prompt-regexp)
+       (expect "> " :to-match comint-prompt-regexp))
+     (expect comint-prompt-regexp :to-equal "^"))
+    (expect comint-prompt-regexp :to-equal "^")))
 
 
 (require 'compile)


### PR DESCRIPTION
As brought up in #149, it is not cool for lua-mode to set `comint-prompt-regexp` globally, so let's convert it to a local variable inside `lua-process-buffer`.