### PR TITLE
Fix typo

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -40,7 +40,7 @@
 
 ;;; Commentary:
 
-;; lua-mode provides support for editing Lua, including automatical
+;; lua-mode provides support for editing Lua, including automatic
 ;; indentation, syntactical font-locking, running interactive shell,
 ;; interacting with `hs-minor-mode' and online documentation lookup.
 


### PR DESCRIPTION
Unfortunately I missed that before.  Because `codespell` did not auto-correct because it wanted me to chose from two possible corrections.