### PR TITLE
Fixed order of expected & actual in matcher's message

### DIFF
--- a/test/utils.el
+++ b/test/utils.el
@@ -19,8 +19,8 @@ Fontification check failed for:
         (buttercup-fail "\
 Fontification check failed on line %d for:
 %S
-  Result faces:   %S
-  Expected faces: %S"
+  Expected faces: %S
+  Result faces:   %S"
                         lineno text (car expected-faces) (car result-faces)))
       (setq expected-faces (cdr expected-faces)
             result-faces (cdr result-faces)

--- a/test/utils.el
+++ b/test/utils.el
@@ -20,7 +20,7 @@ Fontification check failed for:
 Fontification check failed on line %d for:
 %S
   Expected faces: %S
-  Result faces:   %S"
+  Actual faces:   %S"
                         lineno text (car expected-faces) (car result-faces)))
       (setq expected-faces (cdr expected-faces)
             result-faces (cdr result-faces)


### PR DESCRIPTION
Also I propose to rename “Result” -> “Actual”