### PR TITLE
Don't use non-deterministic %d with git's export-subst

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -36,7 +36,7 @@
 
 ;; This field is expanded to commit SHA, date & associated heads/tags during
 ;; archive creation.
-;; Revision: $Format:%h (%cD %d)$
+;; Revision: $Format:%h (%cD)$
 ;;
 
 ;;; Commentary:


### PR DESCRIPTION
This prevents GitHub's tarballs from changing depending on whether a
branch points to the commit or not. E.g. on latest master, %d would
evaluate to "master", whereas once master is updated again, the same
commit wouldn't be master anymore, meaning %d evaluates to "".

This is the cause for PRs https://github.com/NixOS/nixpkgs/pull/56123 and
https://github.com/NixOS/nixpkgs/pull/84277