### PR TITLE
Fix reproducibility issue caused by %d pattern in export-subst

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -34,9 +34,9 @@
 
 ;; Keywords: languages, processes, tools
 
-;; This field is expanded to commit SHA, date & associated heads/tags during
+;; This field is expanded to commit SHA and commit date during the
 ;; archive creation.
-;; Revision: $Format:%h (%cD %d)$
+;; Revision: $Format:%h (%cD)$
 ;;
 
 ;;; Commentary:


### PR DESCRIPTION
The current revision string format results in release tarballs that have different content depending on what branches are pointing to a given revision. This is an issue for distributions that download such tarballs (e.g. from GitHub) and validate them agains reference hashes.

See downstream issues NixOS/nixpkgs#71948 and NixOS/nixpkgs#84312