### PR TITLE
Require rx at compile time

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -97,7 +97,8 @@
 
 (require 'comint)
 (require 'newcomment)
-(require 'rx)
+(eval-and-compile
+  (require 'rx))
 
 
 ;; rx-wrappers for Lua


### PR DESCRIPTION
Given rx is a library of macros, it needs to be evaluated at compile time, otherwise many rx macros will be left undefined when installed via package-install.

n.b. Using eval-when-compile here will result in some rx functions being undefined at runtime.