### PR TITLE
Enable variable name fontification in "for" stmts and function arguments

### DIFF
--- a/test/test-font-lock.el
+++ b/test/test-font-lock.el
@@ -100,6 +100,15 @@ foo = bar"
                                   ()
                                   ())))
 
+  (it "does not fontify \"for\" inside strings"
+    ;; Issue #157
+    (expect "local xx = [[
+for abc def
+]]"
+            :to-be-fontified-as '(("local" keyword "xx" variable-name "[[" string)
+                                  ("for abc def" string)
+                                  ("]]" string))))
+
   (it "fontifies \"for x123 =\""
     (expect "for x123 ="
             :to-be-fontified-as '(("for" keyword "x123" variable-name))))

--- a/test/test-font-lock.el
+++ b/test/test-font-lock.el
@@ -68,10 +68,9 @@ _table.sort(foobar)
 
     (expect "_do foo(5) end_"
             :to-be-fontified-as
-            '(nil))
-    )
+            '(nil)))
   (it "fontifies keywords used as attributes"
-     ;; Hint user that keywords cannot be used like that
+    ;; Hint user that keywords cannot be used like that
     (expect "foo(5).end"
             :to-be-fontified-as
             '(("end" keyword)))
@@ -79,20 +78,64 @@ _table.sort(foobar)
             :to-be-fontified-as
             '(("end" keyword)))))
 
+(describe "Fontification of variables"
+  (it "fontifies \"local foo, bar, baz = 1, 2, 3\""
+    (expect "local foo,bar  ,   baz = 1, 2, 3"
+            :to-be-fontified-as '(("local" keyword "foo" variable-name "bar" variable-name "baz" variable-name))))
+
+  (it "fontifies \"local foo, bar, baz\""
+    (expect "local foo,bar  ,   baz"
+            :to-be-fontified-as '(("local" keyword "foo" variable-name "bar" variable-name "baz" variable-name))))
+
+  (it "fontifies \"local x =\" at end of buffer"
+    (expect "local x ="
+            :to-be-fontified-as '(("local" keyword "x" variable-name))))
+
+  (it "fontifies local \"x =\" at end of line"
+    ;; Issue #163
+    (expect "local x =
+
+foo = bar"
+            :to-be-fontified-as '(("local" keyword "x" variable-name)
+                                  ()
+                                  ())))
+
+  (it "fontifies \"for x123 =\""
+    (expect "for x123 ="
+            :to-be-fontified-as '(("for" keyword "x123" variable-name))))
+
+  (it "fontifies \"for x, y, z\""
+    (expect "for x, y, z in "
+            :to-be-fontified-as '(("for" keyword "x" variable-name "y" variable-name "z" variable-name
+                                   "in" keyword)))))
+
 
 (describe "Fontification of function headers"
   (it "fontifies function <name>(...) headers"
-    (expect "function bar() end"
-            :to-be-fontified-as '(("function" keyword "bar" function-name "end" keyword))))
+    (expect "function bar(x, y) end"
+            :to-be-fontified-as '(("function" keyword "bar" function-name
+                                   "x" variable-name "y" variable-name
+                                   "end" keyword))))
   (it "fontifies local function <name>(...) headers"
-    (expect "local function baz() end"
-            :to-be-fontified-as '(("local" keyword "function" keyword "baz" function-name "end" keyword))))
+    (expect "local function baz(x, y) end"
+            :to-be-fontified-as '(("local" keyword "function" keyword "baz" function-name
+                                   "x" variable-name "y" variable-name
+                                   "end" keyword))))
   (it "fontifies <name> = function (...) headers"
-    (expect "qux = function() end"
-            :to-be-fontified-as '(("qux" function-name "function" keyword "end" keyword))))
+    (expect "qux = function(x, y) end"
+            :to-be-fontified-as '(("qux" function-name "function" keyword
+                                   "x" variable-name "y" variable-name
+                                   "end" keyword))))
   (it "fontifies local <name> = function (...) headers"
-    (expect "local quux = function() end"
-            :to-be-fontified-as '(("local" keyword "quux" function-name "function" keyword "end" keyword))))
+    (expect "local quux = function(x, y) end"
+            :to-be-fontified-as '(("local" keyword "quux" function-name "function" keyword
+                                   "x" variable-name "y" variable-name
+                                   "end" keyword))))
+
+  (it "fontifies parameters in function literals"
+    (expect "foo(function(x, y))"
+            :to-be-fontified-as '(("function" keyword
+                                   "x" variable-name "y" variable-name))))
 
   (it "fontifies different variations of headers altogether"
     (expect
@@ -147,7 +190,7 @@ end"
        ("end" keyword))))
 
   (it "does not choke on function names with underscores"
-   (expect
+    (expect
      ;; Check all defun variants, check embedded defuns
      "\
 function foo()

--- a/test/utils.el
+++ b/test/utils.el
@@ -56,16 +56,17 @@ E.g. for properly fontified Lua string \"local x = 100\" it should return
     \"x\" font-lock-variable-name-face
     \"100\" font-lock-constant-face)
 "
-  (let ((pos 0)
-        nextpos
-        result prop newprop)
-    (while pos
-      (setq nextpos (next-property-change pos str)
-            newprop (or (get-text-property pos 'face str)
-                        (get-text-property pos 'font-lock-face str)))
+  (let* ((pos 0)
+         (prop (or (get-text-property pos 'face str)
+                   (get-text-property pos 'font-lock-face str)))
+         (nextpos 0)
+         newprop
+         result)
+    (while nextpos
+      (setq nextpos (next-property-change nextpos str))
+      (setq newprop (when nextpos (or (get-text-property nextpos 'face str)
+                                      (get-text-property nextpos 'font-lock-face str))))
       (when (not (equal prop newprop))
-        (setq prop newprop)
-
         (when (listp prop)
           (when (eq (car-safe (last prop)) 'default)
             (setq prop (butlast prop)))
@@ -76,8 +77,9 @@ E.g. for properly fontified Lua string \"local x = 100\" it should return
               (setq prop nil))))
         (when prop
           (push (substring-no-properties str pos nextpos) result)
-          (push prop result)))
-      (setq pos nextpos))
+          (push prop result))
+        (setq prop newprop
+              pos nextpos)))
     (nreverse result)))
 
 (defun lua-fontify-str (str)


### PR DESCRIPTION
This PR removes the overly magical `lua-make-delimited-matcher` function, and replaces it with a hand-crafted macro for `lua-rx` that matches up to 9 comma separated variable names. That macro enables matching all variables in one go, with a slightly repetitive, but much more readable list of variables

```
...
     (1 font-lock-variable-name-face)
     (2 font-lock-variable-name-face nil noerror)
     (3 font-lock-variable-name-face nil noerror)
...
```


It should also fix issues #157 and #163.