### PR TITLE
`lua-start-proces': don't hang if already running

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -1857,11 +1857,12 @@ This function just searches for a `end' at the beginning of a line."
 PROGRAM defaults to NAME, which defaults to `lua-default-application'.
 When called interactively, switch to the process buffer."
   (interactive)
-  (unless (process-live-p lua-process)
-    (setq name (or name (if (consp lua-default-application)
-                            (car lua-default-application)
-                          lua-default-application)))
-    (setq program (or program lua-default-application))
+  (setq name (or name (if (consp lua-default-application)
+                          (car lua-default-application)
+                        lua-default-application)))
+  (setq program (or program lua-default-application))
+  ;; don't re-initialize if there already is a lua process
+  (unless (comint-check-proc (format "*%s*" name))
     (setq lua-process-buffer (apply #'make-comint name program startfile
                                     (or switches lua-default-command-switches)))
     (setq lua-process (get-buffer-process lua-process-buffer))

--- a/test/test-process.el
+++ b/test/test-process.el
@@ -1,0 +1,21 @@
+;;; test-funcname-at-point.el --- Test the repl functions
+
+;;; Commentary:
+
+;; Test functions to interact with the REPL.
+
+;;; Code:
+
+(describe "`lua-start-process'"
+  (it "doesn't hang for an already-running process"
+    ;; Acquire a *lua* repl buffer
+    (lua-start-process)
+    ;; Input some text
+    (with-current-buffer lua-process-buffer
+      (insert "table.insert"))
+    ;; Try restarting the repl buffer
+    (lua-start-process)
+    ;; `lua-start-process' shouldn't hang
+    (expect t)))
+
+;;; test-process.el ends here

--- a/test/test-process.el
+++ b/test/test-process.el
@@ -9,13 +9,16 @@
 (describe "`lua-start-process'"
   (it "doesn't hang for an already-running process"
     ;; Acquire a *lua* repl buffer
-    (lua-start-process)
-    ;; Input some text
-    (with-current-buffer lua-process-buffer
-      (insert "table.insert"))
-    ;; Try restarting the repl buffer
-    (lua-start-process)
-    ;; `lua-start-process' shouldn't hang
-    (expect t)))
+    (save-current-buffer
+      (funcall-interactively #'lua-start-process)
+      ;; Input some text
+      (with-current-buffer lua-process-buffer
+        (insert "table.insert"))
+      (switch-to-buffer (get-buffer-create "*scratch*"))
+      ;; Try restarting the repl buffer
+      (funcall-interactively #'lua-start-process)
+
+      ;; `lua-start-process' shouldn't hang, and it should have switched back.
+      (expect (current-buffer) :to-be lua-process-buffer))))
 
 ;;; test-process.el ends here


### PR DESCRIPTION
Due to waiting for output, that function hangs if a lua process is already
running, because `make-comint' doesn't recreate the process if it is already
running.