### PR TITLE
Bump version tag

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -12,7 +12,7 @@
 ;;              Aaron Smith <aaron-lua@gelatinous.com>.
 ;;
 ;; URL:         http://immerrr.github.com/lua-mode
-;; Version:     20151025
+;; Version:     20201010
 ;; Package-Requires: ((emacs "24.3"))
 ;;
 ;; This file is NOT part of Emacs.


### PR DESCRIPTION
Since the [last release](https://github.com/immerrr/lua-mode/releases/tag/v20201010), the version tag was not bumped.

I am currently working on adding this package to NonGNU ELPA, and that is based on checking the version tag. The only issue there would be that all changes since would be added to the new version.