### PR TITLE
Enable lexical-binding for tests as required by buttercup

### DIFF
--- a/test/test-electric-mode.el
+++ b/test/test-electric-mode.el
@@ -1,4 +1,4 @@
-;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) -*-
+;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) ; lexical-binding:t -*-
 
 (load (concat (file-name-directory (or load-file-name (buffer-file-name)
                                        default-directory))

--- a/test/test-fill.el
+++ b/test/test-fill.el
@@ -1,4 +1,4 @@
-;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) -*-
+;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) ; lexical-binding:t -*-
 (load (concat (file-name-directory (or load-file-name (buffer-file-name)
                                        default-directory))
               "utils.el") nil 'nomessage 'nosuffix)

--- a/test/test-font-lock.el
+++ b/test/test-font-lock.el
@@ -1,4 +1,4 @@
-;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) -*-
+;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) ; lexical-binding:t -*-
 
 (load (concat (file-name-directory (or load-file-name (buffer-file-name)
                                        default-directory))

--- a/test/test-funcname-at-point.el
+++ b/test/test-funcname-at-point.el
@@ -1,4 +1,4 @@
-;;; test-funcname-at-point.el --- Test `lua-funcname-at-point'
+;;; test-funcname-at-point.el --- Test `lua-funcname-at-point'  -*- lexical-binding:t -*-
 
 ;;; Commentary:
 

--- a/test/test-generic.el
+++ b/test/test-generic.el
@@ -1,4 +1,4 @@
-;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) -*-
+;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) ; lexical-binding:t -*-
 (load (concat (file-name-directory (or load-file-name (buffer-file-name)
                                        default-directory))
               "utils.el") nil 'nomessage 'nosuffix)

--- a/test/test-indentation.el
+++ b/test/test-indentation.el
@@ -1,4 +1,4 @@
-;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) -*-
+;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) ; lexical-binding:t -*-
 ;; -*- lexical-binding: t -*-
 (load (concat (file-name-directory (or load-file-name (buffer-file-name)
                                        default-directory))

--- a/test/test-inferior-process.el
+++ b/test/test-inferior-process.el
@@ -1,4 +1,4 @@
-;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) -*-
+;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) ; lexical-binding:t -*-
 (load (concat (file-name-directory (or load-file-name (buffer-file-name)
                                        default-directory))
               "utils.el") nil 'nomessage 'nosuffix)

--- a/test/test-process.el
+++ b/test/test-process.el
@@ -1,4 +1,4 @@
-;;; test-funcname-at-point.el --- Test the repl functions
+;;; test-funcname-at-point.el --- Test the repl functions -*- lexical-binding:t -*-
 
 ;;; Commentary:
 

--- a/test/test-strings-and-comments.el
+++ b/test/test-strings-and-comments.el
@@ -1,4 +1,4 @@
-;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) -*-
+;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) ; lexical-binding:t -*-
 
 (load (concat (file-name-directory (or load-file-name (buffer-file-name)
                                        default-directory))

--- a/test/utils.el
+++ b/test/utils.el
@@ -1,4 +1,5 @@
-;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) -*-
+;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) ; lexical-binding:t -*-
+
 
 (require 'lua-mode)
 (require 'buttercup)


### PR DESCRIPTION
Tests broke using buttercup 1.26, this commit fixes the breakage by simply enabling lexical binding in all test-related files.

See also: https://github.com/jorgenschaefer/emacs-buttercup/issues/226