### PR TITLE
No longer quote a lambda

### DIFF
--- a/lua-mode.el
+++ b/lua-mode.el
@@ -330,8 +330,9 @@ Should be a list of strings."
   :type 'string
   :group 'lua
   :set 'lua--customize-set-prefix-key
-  :get '(lambda (sym)
-          (let ((val (eval sym))) (if val (single-key-description (eval sym)) ""))))
+  :get (lambda (sym)
+         (let ((val (eval sym)))
+           (if val (single-key-description (eval sym)) ""))))
 
 (defvar lua-mode-menu (make-sparse-keymap "Lua")
   "Keymap for lua-mode's menu.")


### PR DESCRIPTION
Emacs v30's byte-compiler started to warn:

```
lib/lua-mode/lua-mode.el:333:10: Warning: (lambda (sym) ...)
quoted with ' rather than with #'
```

There is no need to quote at all.