### PR TITLE
Use eval in lexical scope to fix tests

### DIFF
--- a/test/test-indentation.el
+++ b/test/test-indentation.el
@@ -46,7 +46,7 @@
                                          (list (car alist-cons) (cdr alist-cons)))
                                        ;; cl-caddr here is to support Emacs<26 that don't have caddr.
                                        (cl-caddr x)))
-                         (expect lua-code :to-be-reindented-the-same-way))))))
+                         (expect lua-code :to-be-reindented-the-same-way))) t)))
 
 (let* ((current-path (or load-file-name (buffer-file-name) default-directory))
        (indentation-tests-dir (concat (file-name-directory current-path) "indentation-tests"))


### PR DESCRIPTION
* Buttercup since 1.34 starts to support oclosure, so eval will be used in dynamic scope by default.
* This patch ensures that eval is using lexical scope to retain previous behavior and fix tests in buttercup >=1.34.